### PR TITLE
feat: Added active states for toolbar buttons

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -33,6 +33,11 @@
     --ring: 240 5% 64.9%;
 
     --radius: 0.5rem;
+
+    --emerald-primary: #10b981;
+    --emerald-glow: rgba(16, 185, 129, 0.12);
+    --emerald-border: rgba(16, 185, 129, 0.24);
+    --emerald-bg: rgba(16, 185, 129, 0.04);
   }
 
   .dark {
@@ -64,6 +69,11 @@
     --destructive-foreground: 0 85.7% 97.3%;
 
     --ring: 240 3.7% 25%;
+
+    --cyan-primary: #00e5ff;
+    --cyan-glow: rgba(0, 229, 255, 0.12);
+    --cyan-border: rgba(0, 229, 255, 0.24);
+    --cyan-bg: rgba(0, 229, 255, 0.04);
   }
 }
 
@@ -367,4 +377,44 @@
   main > [class*='border-b']:nth-child(2) {
     display: none !important;
   }
+}
+
+/* Toolbar buttons (Cyan/Emerald) */
+
+.rte-toolbar-btn.is-active {
+  background: var(--emerald-bg);
+  color: var(--emerald-primary);
+  box-shadow: 0 0 8px var(--emerald-glow);
+  animation: rte-btn-activate 200ms ease;
+  position: relative;
+}
+
+.dark .rte-toolbar-btn.is-active {
+  background: var(--cyan-bg);
+  color: var(--cyan-primary);
+  box-shadow: 0 0 8px var(--cyan-glow);
+}
+
+.rte-toolbar-btn.is-active::after {
+  content: "";
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--emerald-primary);
+  box-shadow: 0 0 6px var(--emerald-glow);
+}
+
+.dark .rte-toolbar-btn.is-active::after {
+  background: var(--cyan-primary);
+  box-shadow: 0 0 6px var(--cyan-glow);
+}
+
+@keyframes rte-btn-activate {
+  0% { transform: scale(0.92); }
+  50% { transform: scale(1.06); }
+  100% { transform: scale(1); }
 }

--- a/src/pages/Editor/Toolbar.tsx
+++ b/src/pages/Editor/Toolbar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import type { Editor as TiptapEditor } from '@tiptap/react';
 import {
   Bold,
@@ -31,11 +32,22 @@ import { LinkPopover } from './LinkPopover';
 
 const btn = (active: boolean) =>
   cn(
-    'inline-flex h-8 w-8 items-center justify-center rounded-md hover:bg-accent transition disabled:opacity-50 disabled:pointer-events-none',
-    active && 'bg-accent text-accent-foreground'
+    'rte-toolbar-btn relative inline-flex h-8 w-8 items-center justify-center rounded-md transition duration-200 hover:bg-accent hover:text-accent-foreground disabled:opacity-50 disabled:pointer-events-none',
+    active ? 'is-active' : 'text-muted-foreground'
   );
 
 export function Toolbar({ editor }: { editor: TiptapEditor | null }) {
+  // Force re-render on every editor transaction so active states are updated instantly
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!editor) return;
+    const handler = () => setTick((t) => t + 1);
+    editor.on('transaction', handler);
+    return () => {
+      editor.off('transaction', handler);
+    };
+  }, [editor]);
+
   if (!editor) return null;
 
   return (


### PR DESCRIPTION
  - Forced toolbar re-renders on Tiptap transactions for immediate UI feedback
  - Added animated glowing dot indicator for active formatting buttons

<!-- Thanks for contributing! Please fill out the sections below. Smaller PRs land faster. -->

## Summary
Adds a glowing dot below the toolbar buttons when they are active.
<!-- What does this PR do, in 1–3 sentences? -->

## Motivation
While using the editor, when I click Bold it updates after I start typing, and same with other toolbar buttons so it's difficult to keep track of multiple formattings
<!-- Why this change? Link an issue if there is one: closes #123 -->

## Changes

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Chore (build, deps, tooling)

## Screenshots / recording (if visual)
<img width="156" height="67" alt="Dark" src="https://github.com/user-attachments/assets/05503faf-fd36-4de9-b586-3f279d38fbf0" />
<img width="159" height="57" alt="Light" src="https://github.com/user-attachments/assets/6b6f4c3e-3602-44c1-8551-4fc92a667dd5" />

<!-- Drop images or short clips here -->

## How to test

<!-- Repro steps a reviewer can copy/paste -->

1. `npm install`
2. `npm run dev`
3. …

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [ ] I've updated the README / CHANGELOG if user-facing
- [x] No new `any` types
- [x] No paid Tiptap Pro / Cloud features introduced